### PR TITLE
Support custom mapping for inPixel metadata EPD-1520

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+2.2.0 / 2017-01-27
+==================
+
+  * Adds ability to support custom mapping for in pixel metadata 
+
 2.1.1 / 2017-01-04
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,14 +65,15 @@ Parsely.prototype.page = function(page) {
   };
 
   if (this.options.inPixelMetadata) {
+    var aliasedProps = page.properties(this.options.customMapping);
     var metadata = {
-      articleSection: page.category() || properties.category,
-      thumbnailUrl: properties.imageUrl,
-      dateCreated: properties.created,
-      headline: properties.headline,
-      keywords: properties.keywords,
-      creator: properties.author,
-      url: properties.url
+      articleSection: aliasedProps.articleSection || page.category() || aliasedProps.category,
+      thumbnailUrl: aliasedProps.thumbnailUrl || aliasedProps.imageUrl,
+      dateCreated: aliasedProps.dateCreated || aliasedProps.created,
+      headline: aliasedProps.headline,
+      keywords: aliasedProps.keywords,
+      creator: aliasedProps.creator || aliasedProps.author,
+      url: aliasedProps.url
     };
 
     // strip any undefined or nulls

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-parsely",
   "description": "The Parsely analytics.js integration.",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,7 +16,8 @@ describe('Parsely', function() {
     apiKey: 'example.com',
     dynamicTracking: false,
     inPixelMetadata: false,
-    trackEvents: false
+    trackEvents: false,
+    customMapping: {}
   };
 
   beforeEach(function() {
@@ -135,6 +136,39 @@ describe('Parsely', function() {
         analytics.deepEqual(json.parse(args[0][0].metadata), {
           creator: 'Chris Sperandio',
           url: 'http://localhost:9876/context.html'
+        });
+      });
+
+      it('should let you override default metadata with custom mapping', function() {
+        parsely.options.dynamicTracking = true;
+        parsely.options.inPixelMetadata = true;
+        parsely.options.customMapping = {
+          kanye: 'articleSection',
+          drake: 'thumbnailUrl',
+          weezy: 'dateCreated',
+          breezy: 'headline',
+          jeezy: 'keywords',
+          kdot: 'creator',
+          weeknd: 'url'
+        };
+        analytics.page({
+          kanye: 'father stretch my hands pt.1',
+          drake: 'started from the bottom',
+          weezy: 'running back',
+          breezy: 'loyal',
+          jeezy: 'put on',
+          kdot: 'm.A.A.d city',
+          weeknd: 'Reminder'
+        });
+        var args = window.PARSELY.beacon.trackPageView.args;
+        analytics.deepEqual(json.parse(args[0][0].metadata), {
+          articleSection: 'father stretch my hands pt.1',
+          thumbnailUrl: 'started from the bottom',
+          dateCreated: 'running back',
+          headline: 'loyal',
+          keywords: 'put on',
+          creator: 'm.A.A.d city',
+          url: 'Reminder'
         });
       });
     });


### PR DESCRIPTION
This PR allows you to make custom mappings for the in pixel metadata, which was a requested feature from a customer. This is not a breaking change since we fallback on current behavior (aka our spec).

*NOTE*: we're basically going to rely on the customer to spell the semantic parsely props correct in their text-map settings.

## TODO

- [ ] metadata
- [ ] site-docs
- [ ] deploy

@sperand-io @tsholmes @anoonan @ladanazita 