### PR TITLE
correct pub_date field to pub_date_tmsp

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+2.2.2 / 2017-03-17
+==================
+
+  * Fix publication date field (pub_date_tmsp, not pub_date)
+
 2.2.1 / 2017-03-09
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -70,7 +70,7 @@ Parsely.prototype.page = function(page) {
     var metadata = {
       section: aliasedProps.section || page.category(),
       image_url: aliasedProps.image_url || aliasedProps.imageUrl,
-      pub_date: aliasedProps.pub_date || aliasedProps.created,
+      pub_date_tmsp: aliasedProps.pub_date_tmsp || aliasedProps.created,
       title: aliasedProps.title || page.title(),
       tags: aliasedProps.tags,
       authors:  aliasedProps.authors,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -149,7 +149,7 @@ describe('Parsely', function() {
         parsely.options.customMapping = {
           kanye: 'section',
           drake: 'image_url',
-          weezy: 'pub_date',
+          weezy: 'pub_date_tmsp',
           breezy: 'title',
           jeezy: 'tags',
           kdot: 'authors',
@@ -170,7 +170,7 @@ describe('Parsely', function() {
         analytics.deepEqual(json.parse(args[0][0].metadata), {
           section: 'father stretch my hands pt.1',
           image_url: 'started from the bottom',
-          pub_date: 'running back',
+          pub_date_tmsp: 'running back',
           title: 'loyal',
           tags: ['put on'],
           authors: ['m.A.A.d city'],


### PR DESCRIPTION
James from Parse.ly here. I made a mistake regarding the `pub_date` field name; that actually needs to be `pub_date_tmsp`.

cc: @sperand-io 