### PR TITLE
Add support for video tracking analytics

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,3 @@
 {
-  "extends": "@segment/eslint-config/browser/legacy",
-  "rules": {
-    "use-isnan": 1
-  }
+  "extends": "@segment/eslint-config/browser/legacy"
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "@segment/eslint-config/browser/legacy"
+  "extends": "@segment/eslint-config/browser/legacy",
+  "rules": {
+    "use-isnan": 1
+  }
 }

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,6 @@ test-browser: install
 	@$(KARMA) start $(KARMA_FLAGS) $(KARMA_CONF)
 
 # Default test target.
-test: lint test-browser
+test: install lint test-browser
 .PHONY: test
 .DEFAULT_GOAL = test

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,6 +97,31 @@ Parsely.prototype.page = function(page) {
  */
 
 Parsely.prototype.track = function(track) {
+  var event = track.event();
+  var videoEvents = {
+    'Video Content Started'     : 'trackPlay',
+    'Video Playback Paused'     : 'trackPause',
+    'Video Playback Interrupted': 'reset'
+  };
+
+  if (videoEvents.hasOwnProperty(event) && window.PARSELY.video) {
+    var vidId = track.proxy('properties.assetId');
+    var urlOverride = track.proxy('context.page.url');
+
+    // https://www.parse.ly/help/integration/video/#video-metadata
+    // https://paper.dropbox.com/doc/Segment-Video-Spec-jdrVhQdGo9aUTQ2kMsbnx
+    var metadata = reject({
+      title: track.proxy('properties.title'),
+      pub_date_tmsp: + new Date(track.proxy('properties.airdate')),
+      image_url: track.proxy('properties.imageUrl'),
+      section: track.proxy('properties.genre'),
+      authors: [track.proxy('properties.publisher')],
+      tags: track.proxy('properties.tags')
+    }, function(value) { return value == null || typeof value === NaN; });
+    
+    window.PARSELY.video[videoEvents[event]](vidId, metadata, urlOverride);
+  }
+
   if (this.options.trackEvents) {
     window.PARSELY.beacon.trackPageView({
       data: track.properties(),

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,15 +97,16 @@ Parsely.prototype.page = function(page) {
  */
 
 Parsely.prototype.track = function(track) {
-  if (this.options.trackEvents) {
-    window.PARSELY.beacon.trackPageView({
-      data: track.properties(),
-      action: track.event(),
-      url: track.proxy('context.page.url'),
-      urlref: track.proxy('context.page.referrer'),
-      js: 1
-    });
-  }
+  /**
+  * Because Parse.ly has two possible .track() endpoints, we need to
+  * use a helper function to alias track calls. This is because we are
+  * using spec'd event names/functions. If we call .track() within them,
+  * it will trigger an infinite loop wherein the spec'd functions get called
+  * continuously. 
+  *
+  * See here: https://github.com/segmentio/analytics.js-integration/blob/master/lib/protos.js#L355
+  */
+  return this.trackDynamicEvent(track);
 };
 
 Parsely.prototype.videoContentStarted = function(track) {
@@ -130,15 +131,7 @@ Parsely.prototype.videoContentStarted = function(track) {
     window.PARSELY.video.trackPlay(vidId, metadata, urlOverride);
   }
   
-  if (this.options.trackEvents) {
-    window.PARSELY.beacon.trackPageView({
-      data: track.properties(),
-      action: track.event(),
-      url: track.proxy('context.page.url'),
-      urlref: track.proxy('context.page.referrer'),
-      js: 1
-    });
-  }
+  return this.trackDynamicEvent(track);
 };
 
 Parsely.prototype.videoPlaybackPaused = function(track) {
@@ -146,7 +139,7 @@ Parsely.prototype.videoPlaybackPaused = function(track) {
     var vidId = track.proxy('properties.assetId');
     var urlOverride = track.proxy('context.page.url');
     var options = track.options(this.name) || {};
-    
+
     // https://www.parse.ly/help/integration/video/#video-metadata
     // https://paper.dropbox.com/doc/Segment-Video-Spec-jdrVhQdGo9aUTQ2kMsbnx
     var metadata = reject({ 
@@ -163,15 +156,7 @@ Parsely.prototype.videoPlaybackPaused = function(track) {
     window.PARSELY.video.trackPause(vidId, metadata, urlOverride);
   }
 
-  if (this.options.trackEvents) {
-    window.PARSELY.beacon.trackPageView({
-      data: track.properties(),
-      action: track.event(),
-      url: track.proxy('context.page.url'),
-      urlref: track.proxy('context.page.referrer'),
-      js: 1
-    });
-  }
+  return this.trackDynamicEvent(track);
 };
 
 Parsely.prototype.videoPlaybackInterrupted = function(track) {
@@ -180,6 +165,10 @@ Parsely.prototype.videoPlaybackInterrupted = function(track) {
     window.PARSELY.video.reset(vidId);
   }
 
+  return this.trackDynamicEvent(track);
+};
+
+Parsely.prototype.trackDynamicEvent = function(track) {
   if (this.options.trackEvents) {
     window.PARSELY.beacon.trackPageView({
       data: track.properties(),

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,29 +97,87 @@ Parsely.prototype.page = function(page) {
  */
 
 Parsely.prototype.track = function(track) {
-  var event = track.event();
-  var videoEvents = {
-    'Video Content Started'     : 'trackPlay',
-    'Video Playback Paused'     : 'trackPause',
-    'Video Playback Interrupted': 'reset'
-  };
+  if (this.options.trackEvents) {
+    window.PARSELY.beacon.trackPageView({
+      data: track.properties(),
+      action: track.event(),
+      url: track.proxy('context.page.url'),
+      urlref: track.proxy('context.page.referrer'),
+      js: 1
+    });
+  }
+};
 
-  if (videoEvents.hasOwnProperty(event) && window.PARSELY.video) {
+Parsely.prototype.videoContentStarted = function(track) {
+  if (window.PARSELY.video) {
     var vidId = track.proxy('properties.assetId');
     var urlOverride = track.proxy('context.page.url');
+    var options = track.options(this.name) || {};
 
     // https://www.parse.ly/help/integration/video/#video-metadata
     // https://paper.dropbox.com/doc/Segment-Video-Spec-jdrVhQdGo9aUTQ2kMsbnx
-    var metadata = reject({
+    var metadata = reject({ 
       title: track.proxy('properties.title'),
       pub_date_tmsp: + new Date(track.proxy('properties.airdate')),
-      image_url: track.proxy('properties.imageUrl'),
+      image_url: options.imageUrl,
       section: track.proxy('properties.genre'),
       authors: [track.proxy('properties.publisher')],
-      tags: track.proxy('properties.tags')
+      tags: track.proxy('properties.keywords')
+      /* eslint-disable use-isnan */
     }, function(value) { return value == null || typeof value === NaN; });
+      /* eslint-enable use-isnan */
+
+    window.PARSELY.video.trackPlay(vidId, metadata, urlOverride);
+  }
+  
+  if (this.options.trackEvents) {
+    window.PARSELY.beacon.trackPageView({
+      data: track.properties(),
+      action: track.event(),
+      url: track.proxy('context.page.url'),
+      urlref: track.proxy('context.page.referrer'),
+      js: 1
+    });
+  }
+};
+
+Parsely.prototype.videoPlaybackPaused = function(track) {
+  if (window.PARSELY.video) {
+    var vidId = track.proxy('properties.assetId');
+    var urlOverride = track.proxy('context.page.url');
+    var options = track.options(this.name) || {};
     
-    window.PARSELY.video[videoEvents[event]](vidId, metadata, urlOverride);
+    // https://www.parse.ly/help/integration/video/#video-metadata
+    // https://paper.dropbox.com/doc/Segment-Video-Spec-jdrVhQdGo9aUTQ2kMsbnx
+    var metadata = reject({ 
+      title: track.proxy('properties.title'),
+      pub_date_tmsp: + new Date(track.proxy('properties.airdate')),
+      image_url: options.imageUrl,
+      section: track.proxy('properties.genre'),
+      authors: [track.proxy('properties.publisher')],
+      tags: options.tags
+      /* eslint-disable use-isnan */
+    }, function(value) { return value == null || typeof value === NaN; });
+      /* eslint-enable use-isnan */
+
+    window.PARSELY.video.trackPause(vidId, metadata, urlOverride);
+  }
+
+  if (this.options.trackEvents) {
+    window.PARSELY.beacon.trackPageView({
+      data: track.properties(),
+      action: track.event(),
+      url: track.proxy('context.page.url'),
+      urlref: track.proxy('context.page.referrer'),
+      js: 1
+    });
+  }
+};
+
+Parsely.prototype.videoPlaybackInterrupted = function(track) {
+  if (window.PARSELY.video) {
+    var vidId = track.proxy('properties.assetId');
+    window.PARSELY.video.reset(vidId);
   }
 
   if (this.options.trackEvents) {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "@segment/analytics.js-integration": "^2.1.0",
     "array-filter": "^1.0.0",
     "do-when": "^1.0.0",
-    "json3": "^3.3.2",
     "is": "3.2.1",
+    "json3": "^3.3.2",
     "reject": "0.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@ndhoule/defaults": "^2.0.1",
     "@ndhoule/each": "^2.0.1",
-    "@segment/analytics.js-integration": "^2.1.0",
+    "@segment/analytics.js-integration": "^3.x",
     "array-filter": "^1.0.0",
     "do-when": "^1.0.0",
     "is": "3.2.1",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -183,6 +183,7 @@ describe('Parsely', function() {
     describe('track', function() {
       beforeEach(function() {
         analytics.stub(window.PARSELY, 'beacon');
+        analytics.stub(window.PARSELY, 'video');
         analytics.stub(window.PARSELY.beacon, 'trackPageView');
       });
 
@@ -209,6 +210,55 @@ describe('Parsely', function() {
         analytics.track('test', { testing: 'test' });
         var args = window.PARSELY.beacon.trackPageView.args;
         analytics.deepEqual(args[0][0].data, { testing: 'test' });
+      });
+
+      describe('video support', function() {
+        var assetId = '12345';
+
+        beforeEach(function() {
+          analytics.stub(window.PARSELY.video, 'trackPlay');
+          analytics.stub(window.PARSELY.video, 'trackPause');
+          analytics.stub(window.PARSELY.video, 'reset');
+        });
+
+        it('should track content view starts', function() {
+          analytics.track('Video Content Started', {
+            assetId: assetId,
+            airdate: 'Mon May 08 2017 11:00:34 GMT-0700 (PDT)',
+            genre: 'Sports',
+            publisher: 'Chris Nixon',
+            tags: ['hockey', 'henrik lundquist', 'rangers']
+          });
+          var args = window.PARSELY.video.trackPlay.args;
+          analytics.equal(args[0][0], assetId);
+          analytics.deepEqual(args[0][1], { pub_date_tmsp: 1494266434000, section: 'Sports', authors: ['Chris Nixon'], tags: ['hockey', 'henrik lundquist', 'rangers'] });
+        });
+
+        it('should track playback paused events', function() {
+          analytics.track('Video Playback Paused', {
+            assetId: assetId,
+            airdate: 'Mon May 08 2017 11:00:34 GMT-0700 (PDT)',
+            genre: 'Sports',
+            publisher: 'Chris Nixon',
+            tags: ['hockey', 'henrik lundquist', 'rangers']
+          });
+          var args = window.PARSELY.video.trackPause.args;
+          analytics.equal(args[0][0], assetId);
+          analytics.deepEqual(args[0][1], { pub_date_tmsp: 1494266434000, section: 'Sports', authors: ['Chris Nixon'], tags: ['hockey', 'henrik lundquist', 'rangers'] });
+        });
+
+        it('should track playback interrupted events', function() {
+          analytics.track('Video Playback Interrupted', { assetId: assetId });
+          var args = window.PARSELY.video.reset.args;
+          analytics.equal(args[0][0], assetId);
+        });
+
+        // TODO: is this desired behavior?
+        it('should also send video events as custom events', function() {
+          parsely.options.trackEvents = true;
+          analytics.track('Video Playback Interrupted', { assetId: assetId });
+          analytics.called(window.PARSELY.beacon.trackPageView);
+        });
       });
     });
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -227,11 +227,17 @@ describe('Parsely', function() {
             airdate: 'Mon May 08 2017 11:00:34 GMT-0700 (PDT)',
             genre: 'Sports',
             publisher: 'Chris Nixon',
-            tags: ['hockey', 'henrik lundquist', 'rangers']
+            keywords: ['hockey', 'henrik lundquist', 'rangers']
+          }, {
+            integrations: {
+              Parsely: {
+                imageUrl: 'http://logo.com'
+              }
+            }
           });
           var args = window.PARSELY.video.trackPlay.args;
           analytics.equal(args[0][0], assetId);
-          analytics.deepEqual(args[0][1], { pub_date_tmsp: 1494266434000, section: 'Sports', authors: ['Chris Nixon'], tags: ['hockey', 'henrik lundquist', 'rangers'] });
+          analytics.deepEqual(args[0][1], { pub_date_tmsp: 1494266434000, image_url: 'http://logo.com', section: 'Sports', authors: ['Chris Nixon'], tags: ['hockey', 'henrik lundquist', 'rangers'] });
         });
 
         it('should track playback paused events', function() {
@@ -239,12 +245,18 @@ describe('Parsely', function() {
             assetId: assetId,
             airdate: 'Mon May 08 2017 11:00:34 GMT-0700 (PDT)',
             genre: 'Sports',
-            publisher: 'Chris Nixon',
-            tags: ['hockey', 'henrik lundquist', 'rangers']
+            publisher: 'Chris Nixon'
+          }, {
+            integrations: {
+              Parsely: {
+                imageUrl: 'http://logo.com',
+                tags: ['hockey', 'henrik lundquist', 'rangers']
+              }
+            }
           });
           var args = window.PARSELY.video.trackPause.args;
           analytics.equal(args[0][0], assetId);
-          analytics.deepEqual(args[0][1], { pub_date_tmsp: 1494266434000, section: 'Sports', authors: ['Chris Nixon'], tags: ['hockey', 'henrik lundquist', 'rangers'] });
+          analytics.deepEqual(args[0][1], { pub_date_tmsp: 1494266434000, image_url: 'http://logo.com', section: 'Sports', authors: ['Chris Nixon'], tags: ['hockey', 'henrik lundquist', 'rangers'] });
         });
 
         it('should track playback interrupted events', function() {


### PR DESCRIPTION
Adds integration between our video spec and parse.ly's [video tracking api](https://www.parse.ly/help/integration/video/).
